### PR TITLE
Rebuild Time and Date widgets only when needed

### DIFF
--- a/lib/applications/clock/main.dart
+++ b/lib/applications/clock/main.dart
@@ -120,6 +120,7 @@ class WorldClockTab extends StatefulWidget {
 }
 
 class _WorldClockTabState extends State<WorldClockTab> {
+  Timer _timer;
   ValueNotifier<String> _timeStringNotifier;
 
   @override
@@ -142,8 +143,15 @@ class _WorldClockTabState extends State<WorldClockTab> {
   @override
   void initState() {
     _timeStringNotifier = ValueNotifier(_formatDateTime(DateTime.now()));
-    Timer.periodic(Duration(seconds: 1), (Timer t) => _getTime());
+    _timer = Timer.periodic(Duration(seconds: 1), (Timer t) => _getTime());
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    // Cancel the timer once we are done with it
+    _timer.cancel();
+    super.dispose();
   }
 
   String _formatDateTime(DateTime dateTime) {

--- a/lib/applications/clock/main.dart
+++ b/lib/applications/clock/main.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:Pangolin/desktop/quicksettings/quick_settings.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -40,15 +41,14 @@ class Clock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     return new MaterialApp(
       title: 'Clock',
-      theme: new ThemeData(
+      theme: ThemeData(
         platform: TargetPlatform.fuchsia,
         primaryColor: Colors.blue[900],
-        brightness: Brightness.dark
+        brightness: Brightness.dark,
       ),
-      home: ClockApp()
+      home: ClockApp(),
     );
   }
 }
@@ -73,7 +73,10 @@ class _ClockApp extends State<ClockApp> with TickerProviderStateMixin {
               controller: tcon,
               indicator: BoxDecoration(
                 color: Theme.of(context).canvasColor,
-                borderRadius: BorderRadius.only(topLeft: Radius.circular(8), topRight: Radius.circular(8)),
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(8),
+                  topRight: Radius.circular(8),
+                ),
               ),
               isScrollable: true,
               tabs: [
@@ -91,25 +94,22 @@ class _ClockApp extends State<ClockApp> with TickerProviderStateMixin {
             PopupMenuButton(
               icon: Icon(Icons.more_vert),
               itemBuilder: (context) => <PopupMenuEntry>[
-                PopupMenuItem(
-                  child: Text("Settings"),
-                  value: "settings"
-                )
+                PopupMenuItem(child: Text("Settings"), value: "settings")
               ],
               onSelected: (value) {
                 if (value == "settings") notImplemented(context);
               },
             ),
-          ]
+          ],
         ),
       ),
       body: TabBarView(
         controller: tcon,
         children: [
           WorldClockTab(),
-          AlarmsTab()
+          AlarmsTab(),
         ],
-      )
+      ),
     );
   }
 }
@@ -120,27 +120,40 @@ class WorldClockTab extends StatefulWidget {
 }
 
 class _WorldClockTabState extends State<WorldClockTab> {
-
-  DateTime _datetime = DateTime.now();
-  Timer _ctimer;
+  ValueNotifier<String> _timeStringNotifier;
 
   @override
   Widget build(BuildContext context) {
-    if (_ctimer == null) _ctimer = Timer.periodic(Duration(seconds: 1), (me) {
-      _datetime = DateTime.now();
-      setState(() {});
-    });
     return Material(
       child: Center(
-        child: Text(
-          "${_datetime.hour}:${_datetime.minute < 10 ? "0"+_datetime.minute.toString() : _datetime.minute}:${_datetime.second < 10 ? "0"+_datetime.second.toString() : _datetime.second}",
-          style: TextStyle(
-            fontSize: 48,
-            fontWeight: FontWeight.bold
-          ),
-        )
+        child: ValueListenableBuilder(
+          valueListenable: _timeStringNotifier,
+          builder: (BuildContext context, String time, Widget child) {
+            return Text(
+              time,
+              style: TextStyle(fontSize: 48, fontWeight: FontWeight.bold),
+            );
+          },
+        ),
       ),
     );
+  }
+
+  @override
+  void initState() {
+    _timeStringNotifier = ValueNotifier(_formatDateTime(DateTime.now()));
+    Timer.periodic(Duration(seconds: 1), (Timer t) => _getTime());
+    super.initState();
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    return DateFormat.Hms().format(dateTime);
+  }
+
+  void _getTime() {
+    final DateTime now = DateTime.now();
+    final String formattedDateTime = _formatDateTime(now);
+    _timeStringNotifier.value = formattedDateTime;
   }
 }
 
@@ -149,7 +162,7 @@ class AlarmsTab extends StatelessWidget {
   Widget build(BuildContext context) {
     return Material(
       child: Center(
-        child: Icon(Icons.timer_rounded)
+        child: Icon(Icons.timer_rounded),
       ),
     );
   }

--- a/lib/desktop/quicksettings/quick_settings.dart
+++ b/lib/desktop/quicksettings/quick_settings.dart
@@ -39,15 +39,17 @@ class QuickSettingsState extends State<QuickSettings> {
   double brightness = 0.8;
   double volume = 0.5;
 
-  String _dateString;
-  String _timeString;
+  ValueNotifier<String> _timeStringNotifier;
+  ValueNotifier<String> _dateStringNotifier;
 
   @override
   void initState() {
     super.initState();
     Pangolin.settingsBox = Hive.box("settings");
-    _timeString = _formatDateTime(DateTime.now(), 'h:mm');
-    _dateString = _formatDateTime(DateTime.now(), 'd MMMM yyyy');
+    _timeStringNotifier =
+        ValueNotifier(_formatDateTime(DateTime.now(), 'h:mm'));
+    _dateStringNotifier =
+        ValueNotifier(_formatDateTime(DateTime.now(), 'd MMMM yyyy'));
     if (!isTesting)
       Timer.periodic(
           Duration(milliseconds: 100), (Timer t) => _getTime(context));
@@ -61,10 +63,9 @@ class QuickSettingsState extends State<QuickSettings> {
         ? _formatDateTime(now, 'h:mm:ss')
         : _formatDateTime(now, 'h:mm');
     final String formattedDate = _formatLocaleDate(now);
-    setState(() {
-      _timeString = formattedTime;
-      _dateString = formattedDate;
-    });
+
+    _timeStringNotifier.value = formattedTime;
+    _dateStringNotifier.value = formattedDate;
   } //
 
   //Default date format
@@ -522,10 +523,22 @@ class QuickSettingsState extends State<QuickSettings> {
                         Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(_timeString, style: biggerFont),
+                            ValueListenableBuilder(
+                              valueListenable: _timeStringNotifier,
+                              builder: (BuildContext context, String time,
+                                  Widget child) {
+                                return Text(time, style: biggerFont);
+                              },
+                            ),
                             //Icon(Icons.brightness_1, size: 10.0,color: Colors.white),
                             Text('  |  ', style: biggerFont),
-                            Text(_dateString, style: biggerFont),
+                            ValueListenableBuilder(
+                              valueListenable: _dateStringNotifier,
+                              builder: (BuildContext context, String date,
+                                  Widget child) {
+                                return Text(date, style: biggerFont);
+                              },
+                            ),
                           ],
                         ),
                       ])),

--- a/lib/desktop/quicksettings/status_tray.dart
+++ b/lib/desktop/quicksettings/status_tray.dart
@@ -42,10 +42,10 @@ class StatusTrayWidget extends StatefulWidget {
 }
 
 class StatusTrayWidgetState extends State<StatusTrayWidget> {
-  String _timeString;
+  ValueNotifier<String> _timeStringNotifier;
   @override
   void initState() {
-    _timeString = _formatDateTime(DateTime.now());
+    _timeStringNotifier = ValueNotifier(_formatDateTime(DateTime.now()));
     if (!isTesting)
       Timer.periodic(Duration(seconds: 1), (Timer t) => _getTime());
     else
@@ -56,9 +56,8 @@ class StatusTrayWidgetState extends State<StatusTrayWidget> {
   void _getTime() {
     final DateTime now = DateTime.now();
     final String formattedDateTime = _formatDateTime(now);
-    setState(() {
-      _timeString = formattedDateTime;
-    });
+
+    _timeStringNotifier.value = formattedDateTime;
   }
 
   String _formatDateTime(DateTime dateTime) {
@@ -117,14 +116,20 @@ class StatusTrayWidgetState extends State<StatusTrayWidget> {
                           ? Colors.white
                           : Colors.black,
                     ),
-                    Text(
-                      _timeString,
-                      style: TextStyle(
-                        fontSize: 15,
-                        color: Pangolin.settingsBox.get("desktopDarkMode")
-                            ? Colors.white
-                            : Colors.black,
-                      ),
+                    ValueListenableBuilder(
+                      valueListenable: _timeStringNotifier,
+                      builder:
+                          (BuildContext context, String time, Widget child) {
+                        return Text(
+                          time,
+                          style: TextStyle(
+                            fontSize: 15,
+                            color: Pangolin.settingsBox.get("desktopDarkMode")
+                                ? Colors.white
+                                : Colors.black,
+                          ),
+                        );
+                      },
                     ),
                   ]),
             ),


### PR DESCRIPTION
## Description

The `Date` and `Time` widgets inside the `QuickSettings` and `StatusTrayWidget` were causing repeated rebuilding of the widget tree instead of rebuilding only the respective widget.

This PR will reduce the number of times the Date and Time widgets are rebuilt and thus improving performance.

Before this fix the entire widget tree was getting rebuilt every second.
Now it will only rebuilt the Date and Time widget when there's a change in date and time.

## Type of change

Please tick the relevant option by putting an X inside the bracket

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] All current GitHub actions pass
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
