### PR TITLE
supportsWeb property on Apps

### DIFF
--- a/lib/desktop/overlays/launcher/launcher_grid.dart
+++ b/lib/desktop/overlays/launcher/launcher_grid.dart
@@ -99,7 +99,16 @@ class LauncherGrid extends StatelessWidget {
                   crossAxisSpacing: 0,
                 ),
                 itemBuilder: (BuildContext context, int index) {
-                  return AppLauncherButton(page[index].packageName!);
+                  final Application application = getApp(page[index].packageName!);
+                  if (!application.canBeOpened) {
+                    return IgnorePointer(
+                      child: Opacity(
+                        opacity: 0.4,
+                        child: AppLauncherButton(application),
+                      ),
+                    );
+                  }
+                  return AppLauncherButton(application);
                 },
               );
             }),

--- a/lib/desktop/taskbar/clock.dart
+++ b/lib/desktop/taskbar/clock.dart
@@ -33,8 +33,7 @@ class DateClockWidget extends StatelessWidget {
         builder: (BuildContext context, String time, Widget? child) => SizedBox(
           width: _pref.isTaskbarHorizontal ? date.characters.length * 10 : 48,
           height: _pref.isTaskbarHorizontal ? 48 : time.characters.length * 9,
-          child: Padding(
-            padding: const EdgeInsets.all(4.0),
+          child: Center(
             child: ClipRRect(
               borderRadius:
                   CommonData.of(context).borderRadius(BorderRadiusType.SMALL),

--- a/lib/desktop/taskbar/taskbar_item.dart
+++ b/lib/desktop/taskbar/taskbar_item.dart
@@ -64,10 +64,6 @@ class _TaskbarItemState extends State<TaskbarItem>
     final _app = applications
         .firstWhere((element) => element.packageName == widget.packageName);
 
-    if (!_app.canBeOpened) {
-      return SizedBox.shrink();
-    }
-
     //Running apps
     //// ITS FAILING HERE
     final hierarchy = WindowHierarchy.of(context);
@@ -104,7 +100,7 @@ class _TaskbarItemState extends State<TaskbarItem>
     }
     final _pref = Provider.of<PreferenceProvider>(context);
     //Build Widget
-    return LayoutBuilder(
+    final Widget finalWidget = LayoutBuilder(
       builder: (context, constraints) => Padding(
         padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 3.0),
         child: SizedBox(
@@ -211,6 +207,14 @@ class _TaskbarItemState extends State<TaskbarItem>
         ),
       ),
     );
+    if (!_app.canBeOpened)
+      return IgnorePointer(
+        child: Opacity(
+          opacity: 0.4,
+          child: finalWidget,
+        ),
+      );
+    return finalWidget;
   }
 
   void _onTap(BuildContext context, LiveWindowEntry entry) {

--- a/lib/desktop/taskbar/taskbar_item.dart
+++ b/lib/desktop/taskbar/taskbar_item.dart
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import 'package:dahlia_backend/dahlia_backend.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:pangolin/utils/app_list.dart';
@@ -59,13 +60,18 @@ class _TaskbarItemState extends State<TaskbarItem>
 
   @override
   Widget build(BuildContext context) {
+    //Selected App
+    final _app = applications
+        .firstWhere((element) => element.packageName == widget.packageName);
+
+    if (_app.breaksWeb && kIsWeb) {
+      return SizedBox.shrink();
+    }
+
     //Running apps
     //// ITS FAILING HERE
     final hierarchy = WindowHierarchy.of(context);
     final windows = hierarchy.entries;
-    //Selected App
-    final _app = applications
-        .firstWhere((element) => element.packageName == widget.packageName);
     //Check if App is running or just pinned
     bool appIsRunning = windows.any(
       (element) => element.registry.extra.stableId == widget.packageName,

--- a/lib/desktop/taskbar/taskbar_item.dart
+++ b/lib/desktop/taskbar/taskbar_item.dart
@@ -64,7 +64,7 @@ class _TaskbarItemState extends State<TaskbarItem>
     final _app = applications
         .firstWhere((element) => element.packageName == widget.packageName);
 
-    if (_app.breaksWeb && kIsWeb) {
+    if (!_app.canBeOpened) {
       return SizedBox.shrink();
     }
 

--- a/lib/utils/app_list.dart
+++ b/lib/utils/app_list.dart
@@ -14,10 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import 'apps_stub.dart' if (dart.library.io) 'package:files/main.dart';
+// ignore: duplicate_import
+import 'apps_stub.dart' if (dart.library.io) 'package:terminal/main.dart';
+
 import 'package:calculator/calculator.dart';
 import 'package:dahlia_backend/dahlia_backend.dart';
 import 'package:dahlia_clock/main.dart';
-import 'package:files/main.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:graft/main.dart';
@@ -26,7 +29,6 @@ import 'package:pangolin/settings/settings.dart';
 import 'package:pangolin/widgets/error_window.dart';
 import 'package:system_logs/main.dart';
 import 'package:task_manager/monitor.dart';
-import 'package:terminal/main.dart';
 import 'package:text_editor/editor.dart';
 import 'package:web_browser/main.dart';
 import 'package:welcome/main.dart';

--- a/lib/utils/app_list.dart
+++ b/lib/utils/app_list.dart
@@ -143,7 +143,7 @@ Application get fallbackApp {
       app: ErrorWindow(), name: "Error", packageName: "io.dahlia.error");
 }
 
-extension appWebExtension on Application {
+extension AppWebExtension on Application {
   bool get canBeOpened {
     if (kIsWeb) return supportsWeb;
     return true;

--- a/lib/utils/app_list.dart
+++ b/lib/utils/app_list.dart
@@ -57,7 +57,7 @@ List<Application> applications = [
       iconName: "terminal",
       category: ApplicationCategory.SYSTEM,
       description: "Execute commands",
-      breaksWeb: true),
+      supportsWeb: false),
   Application(
       color: Colors.amber,
       packageName: "io.dahlia.editor",
@@ -90,7 +90,7 @@ List<Application> applications = [
       iconName: "files",
       category: ApplicationCategory.SYSTEM,
       description: "Browse your local files",
-      breaksWeb: true),
+      supportsWeb: false),
   Application(
       color: Colors.blueAccent,
       packageName: "io.dahlia.media",
@@ -145,7 +145,7 @@ Application get fallbackApp {
 
 extension appWebExtension on Application {
   bool get canBeOpened {
-    if (breaksWeb) return !kIsWeb;
+    if (kIsWeb) return supportsWeb;
     return true;
   }
 }

--- a/lib/utils/app_list.dart
+++ b/lib/utils/app_list.dart
@@ -18,6 +18,7 @@ import 'package:calculator/calculator.dart';
 import 'package:dahlia_backend/dahlia_backend.dart';
 import 'package:dahlia_clock/main.dart';
 import 'package:files/main.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:graft/main.dart';
 import 'package:media/main.dart';
@@ -140,4 +141,11 @@ Application getApp(String packageName) {
 Application get fallbackApp {
   return Application(
       app: ErrorWindow(), name: "Error", packageName: "io.dahlia.error");
+}
+
+extension appWebExtension on Application {
+  bool get canBeOpened {
+    if (breaksWeb) return !kIsWeb;
+    return true;
+  }
 }

--- a/lib/utils/app_list.dart
+++ b/lib/utils/app_list.dart
@@ -17,7 +17,7 @@ limitations under the License.
 import 'package:calculator/calculator.dart';
 import 'package:dahlia_backend/dahlia_backend.dart';
 import 'package:dahlia_clock/main.dart';
-/* import 'package:files/main.dart'; */
+import 'package:files/main.dart';
 import 'package:flutter/material.dart';
 import 'package:graft/main.dart';
 import 'package:media/main.dart';
@@ -25,7 +25,7 @@ import 'package:pangolin/settings/settings.dart';
 import 'package:pangolin/widgets/error_window.dart';
 import 'package:system_logs/main.dart';
 import 'package:task_manager/monitor.dart';
-/* import 'package:terminal/main.dart'; */
+import 'package:terminal/main.dart';
 import 'package:text_editor/editor.dart';
 import 'package:web_browser/main.dart';
 import 'package:welcome/main.dart';
@@ -48,14 +48,15 @@ List<Application> applications = [
       iconName: "calculator",
       category: ApplicationCategory.OFFICE,
       description: "Solve mathematic calculations"),
-  /* Application(
+  Application(
       color: Colors.grey,
       packageName: "io.dahlia.terminal",
       app: Terminal(),
       name: "Terminal",
       iconName: "terminal",
       category: ApplicationCategory.SYSTEM,
-      description: "Execute commands"), */
+      description: "Execute commands",
+      breaksWeb: true),
   Application(
       color: Colors.amber,
       packageName: "io.dahlia.editor",
@@ -80,14 +81,15 @@ List<Application> applications = [
       iconName: "web",
       category: ApplicationCategory.INTERNET,
       description: "Search and browse the web"),
-  /* Application(
+  Application(
       color: Colors.deepOrange,
       packageName: "io.dahlia.files",
       app: Files(),
       name: "Files",
       iconName: "files",
       category: ApplicationCategory.SYSTEM,
-      description: "Browse your local files"), */
+      description: "Browse your local files",
+      breaksWeb: true),
   Application(
       color: Colors.blueAccent,
       packageName: "io.dahlia.media",

--- a/lib/utils/apps_stub.dart
+++ b/lib/utils/apps_stub.dart
@@ -1,0 +1,18 @@
+/// This is made to support apps that depends on dart:io or dart:ffi
+library stub;
+
+import 'package:flutter/widgets.dart';
+
+class Files extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.shrink();
+  }
+}
+
+class Terminal extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.shrink();
+  }
+}

--- a/lib/utils/wm_api.dart
+++ b/lib/utils/wm_api.dart
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import 'package:dahlia_backend/dahlia_backend.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pangolin/utils/app_list.dart';
 import 'package:pangolin/widgets/error_window.dart';
@@ -82,8 +81,8 @@ class WmAPI {
 
   void openApp(String packageName) {
     final application = getApp(packageName);
-    if (application.breaksWeb && kIsWeb) {
-      throw 'Can not open a new application that breaks the web on the web';
+    if (!application.canBeOpened) {
+      throw 'The app couldn not be opened';
     }
     final LiveWindowEntry _window = windowEntry.newInstance(
       application.app ?? ErrorWindow(),

--- a/lib/utils/wm_api.dart
+++ b/lib/utils/wm_api.dart
@@ -82,7 +82,8 @@ class WmAPI {
   void openApp(String packageName) {
     final application = getApp(packageName);
     if (!application.canBeOpened) {
-      throw 'The app couldn not be opened';
+      return;
+      // throw 'The app couldn not be opened';
     }
     final LiveWindowEntry _window = windowEntry.newInstance(
       application.app ?? ErrorWindow(),

--- a/lib/utils/wm_api.dart
+++ b/lib/utils/wm_api.dart
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import 'package:dahlia_backend/dahlia_backend.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pangolin/utils/app_list.dart';
 import 'package:pangolin/widgets/error_window.dart';
@@ -80,12 +81,16 @@ class WmAPI {
   }
 
   void openApp(String packageName) {
+    final application = getApp(packageName);
+    if (application.breaksWeb && kIsWeb) {
+      throw 'Can not open a new application that breaks the web on the web';
+    }
     final LiveWindowEntry _window = windowEntry.newInstance(
-      getApp(packageName).app ?? ErrorWindow(),
+      application.app ?? ErrorWindow(),
       {
-        WindowEntry.title: getApp(packageName).name,
+        WindowEntry.title: application.name,
         WindowEntry.icon:
-            AssetImage("assets/icons/${getApp(packageName).iconName}.png"),
+            AssetImage("assets/icons/${application.iconName}.png"),
         WindowExtras.stableId: packageName,
         GeometryWindowFeature.size: MediaQuery.of(context).size.width < 1920
             ? Size(720, 480)

--- a/lib/widgets/app_launcher_button.dart
+++ b/lib/widgets/app_launcher_button.dart
@@ -24,17 +24,19 @@ import 'package:pangolin/utils/wm_api.dart';
 import 'package:provider/provider.dart';
 
 class AppLauncherButton extends StatefulWidget {
-  final String packageName;
-  const AppLauncherButton(this.packageName);
+  final Application application;
+  const AppLauncherButton(this.application);
 
   @override
   _AppLauncherButtonState createState() => _AppLauncherButtonState();
 }
 
 class _AppLauncherButtonState extends State<AppLauncherButton> {
+
+  Application get application => widget.application;
+
   @override
   Widget build(BuildContext context) {
-    final Application application = getApp(widget.packageName);
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: Material(
@@ -53,7 +55,7 @@ class _AppLauncherButtonState extends State<AppLauncherButton> {
               focusColor: CommonData.of(context).textColor(),
               onTap: () {
                 Shell.of(context, listen: false).dismissEverything();
-                WmAPI.of(context).openApp(widget.packageName);
+                WmAPI.of(context).openApp(application.packageName!);
               },
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
## Description

Some apps aren't available on the web, such as the Terminal and Files Manager. This PR adds a property that enable apps to tell if they can run on the web or not. If not, they won't show up

Depends on https://github.com/dahliaOS/backend/pull/5 to be landed first

## Type of change

Please tick the relevant option by putting an X inside the bracket

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] All current GitHub actions pass
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
