### PR TITLE
Add architecture information into the about page

### DIFF
--- a/lib/components/settings/pages/about.dart
+++ b/lib/components/settings/pages/about.dart
@@ -123,6 +123,12 @@ class SettingsPageAbout extends StatelessWidget {
                 leading: const Icon(Icons.memory),
                 title: kernel,
               ),
+              const SettingsContentHeader("Architecture"),
+              SettingsCard.withExpandable(
+                value: false,
+                leading: const Icon(Icons.architecture),
+                title: architecture,
+              ),
               const SettingsContentHeader("Desktop"),
               SettingsCard.withExpandable(
                 value: false,

--- a/lib/utils/data/globals.dart
+++ b/lib/utils/data/globals.dart
@@ -41,6 +41,20 @@ String get kernel {
   }
 }
 
+String get architecture {
+  if (!kIsWeb) {
+    if (!Platform.isWindows) {
+      ProcessResult result = Process.runSync('uname', ['-p']);
+      var architechtureString = result.stdout;
+      return architechtureString.toString().replaceAll('\n', '');
+    } else {
+      return "x86_64 / ARM64 based Windows operating system";
+    }
+  } else {
+    return "Unkown architecture";
+  }
+}
+
 String pangolinCommit = "8c5eea993a89446b3bb0b9e313cdea1d06bf8477";
 String fullPangolinVersion = pangolinCommit;
 


### PR DESCRIPTION
This merge includes:
* Display the architecture of your system in the about section of the settings apps
Web will just pronounce itself as "Unknown architecture"

 - Changes should be made for Windows in the future (cc @nmcain)