### PR TITLE
Settings: display proper accent color names

### DIFF
--- a/lib/components/settings/data/presets.dart
+++ b/lib/components/settings/data/presets.dart
@@ -23,18 +23,56 @@ class SettingsPresets {
   const SettingsPresets._();
 
   //List with presets for the system accent colors
-  static late List<AccentColorDataModel> accentColorPresets;
+  static List<AccentColorDataModel> get accentColorPresets => getAccentColorPresets();
 
   //List with presets for the system theme modes
   //TODO add automatic option based on time / sunrise-sunset
-  static late List<ThemeModeDataModel> themeModePresets;
+  static List<ThemeModeDataModel> get themeModePresets => getThemeModePresets();
 
   //List with presets for the taskbar alignment
-  static late List<TaskbarAlignmentModelData> taskbarAlignmentPresets;
+  static List<TaskbarAlignmentModelData> get taskbarAlignmentPresets => getTaskbarAlignmentPresets();
 
-  static void loadPresets() {
-    //load the data for the accent color presets
-    accentColorPresets = List.from(
+  static List<ThemeModeDataModel> getThemeModePresets()
+  {
+//load the data for the theme mode presets
+    return List.from(
+      [
+        const ThemeModeDataModel(
+          Color(0xffffffff),
+          "Light",
+          false,
+        ),
+        const ThemeModeDataModel(
+          Color(0xff0a0a0a),
+          "Dark",
+          true,
+        ),
+      ],
+      growable: false,
+    );
+  }
+
+  static List<TaskbarAlignmentModelData> getTaskbarAlignmentPresets()
+  {
+//load the data for the taskbar alignment presets
+    return List.from(
+      [
+        const TaskbarAlignmentModelData(
+          "Start",
+          false,
+        ),
+        const TaskbarAlignmentModelData(
+          "Center",
+          true,
+        ),
+      ],
+      growable: false,
+    );
+  }
+
+  static List<AccentColorDataModel> getAccentColorPresets() {
+//load the data for the accent color presets
+    return List.from(
       [
         AccentColorDataModel(
           const Color(0xFFFF5722),
@@ -71,38 +109,6 @@ class SettingsPresets {
         AccentColorDataModel(
           const Color(0xFF455a64),
           LSX.settings.pagesCustomizationThemeColorAnthracite,
-        ),
-      ],
-      growable: false,
-    );
-
-    //load the data for the theme mode presets
-    themeModePresets = List.from(
-      [
-        const ThemeModeDataModel(
-          Color(0xffffffff),
-          "Light",
-          false,
-        ),
-        const ThemeModeDataModel(
-          Color(0xff0a0a0a),
-          "Dark",
-          true,
-        ),
-      ],
-      growable: false,
-    );
-
-    //load the data for the taskbar alignment presets
-    taskbarAlignmentPresets = List.from(
-      [
-        const TaskbarAlignmentModelData(
-          "Start",
-          false,
-        ),
-        const TaskbarAlignmentModelData(
-          "Center",
-          true,
         ),
       ],
       growable: false,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,6 @@ import 'dart:io' show Platform;
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:pangolin/components/settings/data/presets.dart';
 import 'package:pangolin/components/shell/desktop.dart';
 import 'package:pangolin/services/locales/generated_asset_loader.g.dart';
 import 'package:pangolin/services/visual_engine/visual_engine.dart';
@@ -47,9 +46,6 @@ Future<void> main() async {
 
   //initialize the localization engine
   await EasyLocalization.ensureInitialized();
-
-  //load customization presets
-  SettingsPresets.loadPresets();
 
   //load visual engine
   await loadVisualEngine();


### PR DESCRIPTION
Adjusted AccentColorPresets to have proper localization strings as names by refactoring SettingsPresets static members into getters

## Description

- Fixed a bug in which the names of accent colors in the settings window and quick settings would show up as their localization keys rather than their names.
- This was done by refactoring SettingsPresets into a series of getter functions, rather than having all of its static members initialized in main.
- This fix also removes Easy Localization warnings which occurred in the debug console 

## Screenshots (if appropriate):

Before: 
![image](https://user-images.githubusercontent.com/7935418/157520495-7416cadc-a81b-4352-824e-5ec02e0ff009.png)

After:
![image](https://user-images.githubusercontent.com/7935418/157520584-4005c663-cea8-4407-b64f-5152da72e1fc.png)
![image](https://user-images.githubusercontent.com/7935418/157520597-cae7691b-3315-4044-8623-67b3066c615e.png)


## Type of change

Please tick the relevant option by putting an X inside the bracket

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] All current GitHub actions pass
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
