### PR TITLE
Implement acrylic switch to Searchbar widget

### DIFF
--- a/lib/components/overlays/launcher/launcher_overlay.dart
+++ b/lib/components/overlays/launcher/launcher_overlay.dart
@@ -206,6 +206,7 @@ class _SearchState extends State<Search> {
           leading: const Icon(Icons.search),
           trailing: const Icon(Icons.menu),
           hint: "Search Device, Apps and Web",
+          acrylic: false,
           controller: TextEditingController(),
         ),
       ),

--- a/lib/components/overlays/search/search_overlay.dart
+++ b/lib/components/overlays/search/search_overlay.dart
@@ -114,6 +114,7 @@ class _SearchOverlayState extends State<SearchOverlay>
                       leading: const Icon(Icons.search),
                       trailing: const Icon(Icons.menu_rounded),
                       onTextChanged: searchService.globalSearch,
+                      acrylic: false,
                     ),
                   ),
 

--- a/lib/components/overlays/search/widgets/searchbar.dart
+++ b/lib/components/overlays/search/widgets/searchbar.dart
@@ -30,6 +30,10 @@ class Searchbar extends StatelessWidget {
   final FocusNode? focusNode;
   final ValueChanged<String>? onTextChanged;
 
+  /// Enable or disable the acrylic effect of this seachbar.
+  /// When disabled, a semi-transparent layer is applied instead.
+  final bool acrylic;
+
   const Searchbar({
     Key? key,
     required this.leading,
@@ -42,6 +46,7 @@ class Searchbar extends StatelessWidget {
     this.text = "",
     this.color,
     this.onTextChanged,
+    this.acrylic = true,
   }) : super(key: key);
 
   @override
@@ -52,6 +57,7 @@ class Searchbar extends StatelessWidget {
           CommonData.of(context).borderRadius(BorderRadiusType.medium),
       width: 800,
       height: 48,
+      acrylic: acrylic,
       child: Material(
         type: MaterialType.transparency,
         child: Row(

--- a/lib/components/settings/settings.dart
+++ b/lib/components/settings/settings.dart
@@ -274,6 +274,7 @@ class _SettingsSearchBar extends StatelessWidget {
             hint: 'Search settings',
             leading: const Icon(Icons.search_rounded),
             trailing: const Icon(Icons.close_rounded),
+            acrylic: false,
           )
         : Container(
             height: 16,

--- a/lib/widgets/global/box/box_container.dart
+++ b/lib/widgets/global/box/box_container.dart
@@ -97,6 +97,10 @@ class BoxContainer extends StatelessWidget {
   final double? height;
   final bool outline;
 
+  /// Enable or disable the acrylic effect of this container.
+  /// When disabled, a semi-transparent layer is applied instead.
+  final bool acrylic;
+
   const BoxContainer({
     Key? key,
     this.child,
@@ -106,11 +110,13 @@ class BoxContainer extends StatelessWidget {
     this.width,
     this.height,
     this.outline = false,
+    this.acrylic = true,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final bool _darkMode = Theme.of(context).brightness == Brightness.dark;
+    final Widget innerChild = child ?? Container();
     return Container(
       width: width,
       height: height,
@@ -134,9 +140,17 @@ class BoxContainer extends StatelessWidget {
       ),
       child: ClipRRect(
         borderRadius: borderRadius,
-        child: AcrylicLayer(
-          child: child ?? Container(),
-        ),
+        child: acrylic
+            ? AcrylicLayer(
+                child: innerChild,
+              )
+            : CustomPaint(
+                painter: AcrylicLayerPainter(
+                  darkMode: _darkMode,
+                  tintColor: Theme.of(context).colorScheme.secondary,
+                ),
+                child: innerChild,
+              ),
       ),
     );
   }


### PR DESCRIPTION
## Description

Implements acrylic switch to `Searchbar` widget. This switch prevents that widget from rendering the blur effect unnecessarily.

In some places, the search bar's position is not fixed and it scrolls within the list. However, it renders the blur effect again and this can affect the performance of this desktop environment. Also, it creates a bug, the blur effect of the settings app's search bar is affected by the selected widget. For example, see the screenshot below:
 
![Screenshot from 2022-03-12 14-02-22](https://user-images.githubusercontent.com/31767631/158179130-e05c9310-5e0c-4abc-b46e-98143f06b40a.png)
![Screenshot from 2022-03-12 14-02-46](https://user-images.githubusercontent.com/31767631/158179133-d173c695-3847-4a98-b857-3f8436a1df5e.png)

With this acrylic switch, the search bar's blur effect can be disabled, and also this can improve the general performance of this desktop environment. Also, this switch fixes the bug I mentioned above.

After this switch, the settings app's search bar looks like this:
![Screenshot from 2022-03-12 14-06-22](https://user-images.githubusercontent.com/31767631/158179742-8e093306-f799-478c-ac14-8df262cd3578.png)

For now, I disabled the search bar's blur effect in the settings app, launcher overlay, and search overlay as I think it isn't necessary to re-render this effect in these places.

## Type of change

Please tick the relevant option by putting an X inside the bracket

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] All current GitHub actions pass
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
