### PR TITLE
[Settings] Center hint text in search bar and fix padding.

### DIFF
--- a/lib/components/overlays/search/widgets/searchbar.dart
+++ b/lib/components/overlays/search/widgets/searchbar.dart
@@ -72,7 +72,9 @@ class Searchbar extends StatelessWidget {
                 focusNode: focusNode,
                 controller: controller,
                 textAlign: TextAlign.center,
+                maxLength: 15,
                 decoration: InputDecoration(
+                  counterText: "",
                   hintText: hint,
                   border: InputBorder.none,
                   focusedBorder: InputBorder.none,

--- a/lib/components/settings/settings.dart
+++ b/lib/components/settings/settings.dart
@@ -111,7 +111,7 @@ class _SettingsHomeState extends State<_SettingsHome> {
                                           vertical: 2.0,
                                           horizontal: 8,
                                         )
-                                      : const EdgeInsets.only(left: 0),
+                                      : const EdgeInsets.all(0),
                                   child: isSearch
                                       ? _SettingsSearchBar(
                                           isExpanded: isExpanded,

--- a/lib/components/settings/settings.dart
+++ b/lib/components/settings/settings.dart
@@ -104,14 +104,14 @@ class _SettingsHomeState extends State<_SettingsHome> {
                                 height: 16,
                               )
                             : SizedBox(
-                                height: !isTile ? 40 : 60,
+                                height: !isTile ? 46 : 60,
                                 child: Padding(
                                   padding: isTile
                                       ? const EdgeInsets.symmetric(
                                           vertical: 2.0,
                                           horizontal: 8,
                                         )
-                                      : const EdgeInsets.only(left: 8),
+                                      : const EdgeInsets.only(left: 0),
                                   child: isSearch
                                       ? _SettingsSearchBar(
                                           isExpanded: isExpanded,


### PR DESCRIPTION
Centers search bar hint text by increasing it to 46 pixels high. Will submit an issue to the flutter repo.

Also fixes some padding to make the search bar more symmetric.