### PR TITLE
Correctly clip `ListTile` in `ListView`.

### DIFF
--- a/lib/components/overlays/launcher/app_launcher_button.dart
+++ b/lib/components/overlays/launcher/app_launcher_button.dart
@@ -93,63 +93,66 @@ class _AppLauncherTileState extends State<AppLauncherTile> {
       onEnter: (details) => setState(() => _hover = true),
       onExit: (details) => setState(() => _hover = false),
       child: GestureDetector(
-        child: ListTile(
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-          shape: Constants.smallShape,
-          dense: true,
-          leading: SizedBox.fromSize(
-            size: const Size.square(32),
-            child: AutoVisualResource(
-              resource: widget.application.icon?.main ?? "",
-              size: 32,
+        child: Material(
+          color: Colors.transparent,
+          child: ListTile(
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            shape: Constants.smallShape,
+            dense: true,
+            leading: SizedBox.fromSize(
+              size: const Size.square(32),
+              child: AutoVisualResource(
+                resource: widget.application.icon?.main ?? "",
+                size: 32,
+              ),
             ),
-          ),
-          title: Text(
-            widget.application.getLocalizedName(context.locale),
-            overflow: TextOverflow.ellipsis,
-          ),
-          subtitle: widget.application.comment != null
-              ? Text(
-                  widget.application.getLocalizedComment(context.locale)!,
-                  overflow: TextOverflow.ellipsis,
-                )
-              : null,
-          trailing: Offstage(
-            offstage: !_hover,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                QuickActionButton(
-                  size: 32,
-                  margin: const EdgeInsets.symmetric(horizontal: 4),
-                  padding: EdgeInsets.zero,
-                  leading: const Icon(Icons.push_pin_rounded),
-                  onPressed: () {
-                    CustomizationService.current
-                        .togglePinnedApp(widget.application.id);
-                  },
-                ),
-                const QuickActionButton(
-                  size: 32,
-                  margin: EdgeInsets.symmetric(horizontal: 4),
-                  padding: EdgeInsets.zero,
-                  leading: Icon(Icons.settings_outlined),
-                ),
-                const QuickActionButton(
-                  size: 32,
-                  margin: EdgeInsets.symmetric(horizontal: 4),
-                  padding: EdgeInsets.zero,
-                  leading: Icon(Icons.more_vert_rounded),
-                ),
-              ],
+            title: Text(
+              widget.application.getLocalizedName(context.locale),
+              overflow: TextOverflow.ellipsis,
             ),
+            subtitle: widget.application.comment != null
+                ? Text(
+                    widget.application.getLocalizedComment(context.locale)!,
+                    overflow: TextOverflow.ellipsis,
+                  )
+                : null,
+            trailing: Offstage(
+              offstage: !_hover,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  QuickActionButton(
+                    size: 32,
+                    margin: const EdgeInsets.symmetric(horizontal: 4),
+                    padding: EdgeInsets.zero,
+                    leading: const Icon(Icons.push_pin_rounded),
+                    onPressed: () {
+                      CustomizationService.current
+                          .togglePinnedApp(widget.application.id);
+                    },
+                  ),
+                  const QuickActionButton(
+                    size: 32,
+                    margin: EdgeInsets.symmetric(horizontal: 4),
+                    padding: EdgeInsets.zero,
+                    leading: Icon(Icons.settings_outlined),
+                  ),
+                  const QuickActionButton(
+                    size: 32,
+                    margin: EdgeInsets.symmetric(horizontal: 4),
+                    padding: EdgeInsets.zero,
+                    leading: Icon(Icons.more_vert_rounded),
+                  ),
+                ],
+              ),
+            ),
+            onTap: () async {
+              await ApplicationService.current.startApp(widget.application.id);
+              if (mounted) Shell.of(context, listen: false).dismissEverything();
+            },
           ),
-          onTap: () async {
-            await ApplicationService.current.startApp(widget.application.id);
-            if (mounted) Shell.of(context, listen: false).dismissEverything();
-          },
         ),
       ),
     );


### PR DESCRIPTION
`Inkwell` in `ListTile` widget isn't clipped correctly because its parent isn't a material widget. Apparently this is the correct behaviour :shrug: https://github.com/flutter/flutter/issues/86584#issuecomment-917068720

Before:

https://github.com/dahliaOS/pangolin_desktop/assets/73116038/d23c36d3-4a7e-4560-8642-3671a0ec41ea

After:

https://github.com/dahliaOS/pangolin_desktop/assets/73116038/615391d7-f059-49fb-aa13-65cd3489b86d
