### PR TITLE
Don't check networks on web

### DIFF
--- a/lib/services/network_manager.dart
+++ b/lib/services/network_manager.dart
@@ -16,12 +16,15 @@ limitations under the License.
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 //TODO Localize this File
 //TODO Remove this pain
 
 List<String> getNetworks() {
+  if (kIsWeb) return [];
+
   final ProcessResult result =
       Process.runSync('nmcli', ['--terse', '-e', 'no', 'dev', 'wifi']);
   final String networks = result.stdout as String;


### PR DESCRIPTION
We currently get exceptions when checking for networks on web. This PR jut adds a check and returns an empty list if we're on web.

Before and After (left and right respectively) :

https://github.com/dahliaOS/pangolin_desktop/assets/73116038/1e66964b-127b-487b-af05-7929176982f1

