### PR TITLE
Improve context menu color

### DIFF
--- a/lib/components/overlays/overview_overlay.dart
+++ b/lib/components/overlays/overview_overlay.dart
@@ -73,7 +73,8 @@ class _OverviewOverlayState extends ShellOverlayState<OverviewOverlay>
                 right: 0,
                 height: 152,
                 child: DecoratedBox(
-                  decoration: BoxDecoration(color: theme.colorScheme.background),
+                  decoration:
+                      BoxDecoration(color: theme.colorScheme.background),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [

--- a/lib/components/overlays/quick_settings/quick_settings_overlay.dart
+++ b/lib/components/overlays/quick_settings/quick_settings_overlay.dart
@@ -61,7 +61,8 @@ enum _TransitionDirection {
   const _TransitionDirection(this.value);
 }
 
-class _QuickSettingsOverlayState extends ShellOverlayState<QuickSettingsOverlay> {
+class _QuickSettingsOverlayState
+    extends ShellOverlayState<QuickSettingsOverlay> {
   static const Map<String, Widget> routes = {
     '/': QsMain(),
     '/pages/account': QsAccountPage(),
@@ -174,7 +175,8 @@ class QsMain extends StatefulWidget {
   State<QsMain> createState() => _QsMainState();
 }
 
-class _QsMainState extends State<QsMain> with StateServiceListener<CustomizationService, QsMain> {
+class _QsMainState extends State<QsMain>
+    with StateServiceListener<CustomizationService, QsMain> {
   bool showTray = false;
 
   @override
@@ -230,9 +232,11 @@ class _QsMainState extends State<QsMain> with StateServiceListener<Customization
                       //TODO Capitalise
                       subtitle: ToggleProperty(
                         base: null,
-                        active: strings.quicksettingsOverlay.quickControlsNetworkSubtitleConnected,
+                        active: strings.quicksettingsOverlay
+                            .quickControlsNetworkSubtitleConnected,
                       ),
-                      enabled: service.enableWifi && !service.enableAirplaneMode,
+                      enabled:
+                          service.enableWifi && !service.enableAirplaneMode,
                       onPressed: (value) => service.enableWifi = value,
                       onMenuPressed: () {
                         QsController.pushRoute(context, "/pages/network");
@@ -240,7 +244,8 @@ class _QsMainState extends State<QsMain> with StateServiceListener<Customization
                     ),
                     QsToggleButton(
                       title: ToggleProperty.singleState(
-                        strings.quicksettingsOverlay.quickControlsBluetoothTitle,
+                        strings
+                            .quicksettingsOverlay.quickControlsBluetoothTitle,
                       ),
                       subtitle: ToggleProperty(
                         base: strings.global.off,
@@ -250,12 +255,14 @@ class _QsMainState extends State<QsMain> with StateServiceListener<Customization
                         base: Icons.bluetooth_disabled_rounded,
                         active: Icons.bluetooth_connected_rounded,
                       ),
-                      enabled: service.enableBluetooth && !service.enableAirplaneMode,
+                      enabled: service.enableBluetooth &&
+                          !service.enableAirplaneMode,
                       onPressed: (value) => service.enableBluetooth = value,
                     ),
                     QsToggleButton(
                       title: ToggleProperty.singleState(
-                        strings.quicksettingsOverlay.quickControlsAirplaneModeTitle,
+                        strings.quicksettingsOverlay
+                            .quickControlsAirplaneModeTitle,
                       ),
                       icon: const ToggleProperty(
                         base: Icons.airplanemode_off_rounded,
@@ -283,7 +290,8 @@ class _QsMainState extends State<QsMain> with StateServiceListener<Customization
                       ),
                       enabled: true,
                       onPressed: (_) {
-                        final int index = context.supportedLocales.indexOf(context.locale);
+                        final int index =
+                            context.supportedLocales.indexOf(context.locale);
                         if (index + 1 < locales.supportedLocales.length) {
                           context.locale = context.supportedLocales[index + 1];
                         } else {
@@ -303,11 +311,13 @@ class _QsMainState extends State<QsMain> with StateServiceListener<Customization
                       ),
                       enabled: true,
                       onPressed: (_) => service.darkMode = !service.darkMode,
-                      onMenuPressed: () => QsController.pushRoute(context, "/pages/theme"),
+                      onMenuPressed: () =>
+                          QsController.pushRoute(context, "/pages/theme"),
                     ),
                     QsToggleButton(
                       title: ToggleProperty.singleState(
-                        strings.quicksettingsOverlay.quickControlsDonotdisturbTitle,
+                        strings.quicksettingsOverlay
+                            .quickControlsDonotdisturbTitle,
                       ),
                       icon: const ToggleProperty.singleState(
                         Icons.do_not_disturb_off_rounded,
@@ -362,7 +372,9 @@ class _QsMainState extends State<QsMain> with StateServiceListener<Customization
             Column(
               children: [
                 QsSlider(
-                  icon: service.muteVolume ? Icons.volume_off_rounded : Icons.volume_up_rounded,
+                  icon: service.muteVolume
+                      ? Icons.volume_off_rounded
+                      : Icons.volume_up_rounded,
                   onChanged: (val) {
                     service.volume = val;
                     service.muteVolume = val == 0;
@@ -372,11 +384,14 @@ class _QsMainState extends State<QsMain> with StateServiceListener<Customization
                   onIconTap: () => service.muteVolume = !service.muteVolume,
                 ),
                 QsSlider(
-                  icon: service.autoBrightness ? Icons.brightness_auto_rounded : Icons.brightness_5_rounded,
+                  icon: service.autoBrightness
+                      ? Icons.brightness_auto_rounded
+                      : Icons.brightness_5_rounded,
                   onChanged: (val) => service.brightness = val,
                   value: service.brightness,
                   steps: 10,
-                  onIconTap: () => service.autoBrightness = !service.autoBrightness,
+                  onIconTap: () =>
+                      service.autoBrightness = !service.autoBrightness,
                 ),
               ],
             ),
@@ -398,7 +413,8 @@ class _QsMainState extends State<QsMain> with StateServiceListener<Customization
                 ),
                 if (PowerService.current.hasBattery)
                   PowerServiceBuilder(
-                    builder: (context, child, percentage, charging, powerSaver) {
+                    builder:
+                        (context, child, percentage, charging, powerSaver) {
                       return QuickActionButton(
                         leading: BatteryIndicator(
                           percentage: percentage,
@@ -591,7 +607,8 @@ class _RenderFixedSizeTransitionStack extends RenderBox
     double extent = 0.0;
     final child = childToMeasure;
     if (child != null) {
-      final StackParentData childParentData = child.parentData! as StackParentData;
+      final StackParentData childParentData =
+          child.parentData! as StackParentData;
       extent = mainChildSizeGetter(child);
       assert(child.parentData == childParentData);
     }
@@ -642,7 +659,9 @@ class _RenderFixedSizeTransitionStack extends RenderBox
     _resolve();
     assert(_resolvedAlignment != null);
     if (childCount == 0) {
-      return (constraints.biggest.isFinite) ? constraints.biggest : constraints.smallest;
+      return (constraints.biggest.isFinite)
+          ? constraints.biggest
+          : constraints.smallest;
     }
 
     double width = constraints.minWidth;
@@ -653,7 +672,8 @@ class _RenderFixedSizeTransitionStack extends RenderBox
     RenderBox? child = startChild;
     int i = 0;
     while (child != null) {
-      final StackParentData childParentData = child.parentData! as StackParentData;
+      final StackParentData childParentData =
+          child.parentData! as StackParentData;
 
       if (!childParentData.isPositioned) {
         final Size childSize = layoutChild(child, nonPositionedConstraints);
@@ -664,7 +684,9 @@ class _RenderFixedSizeTransitionStack extends RenderBox
         }
       }
 
-      child = reverseDirection ? childParentData.nextSibling : childParentData.previousSibling;
+      child = reverseDirection
+          ? childParentData.nextSibling
+          : childParentData.previousSibling;
       i++;
     }
 
@@ -686,16 +708,20 @@ class _RenderFixedSizeTransitionStack extends RenderBox
       layoutChild: (box, constraints) {
         final size = box.getDryLayout(constraints);
 
-        final unboundedWidth = size.width == double.infinity && constraints.maxWidth == double.infinity;
-        final unboundedHeight = size.height == double.infinity && constraints.maxHeight == double.infinity;
+        final unboundedWidth = size.width == double.infinity &&
+            constraints.maxWidth == double.infinity;
+        final unboundedHeight = size.height == double.infinity &&
+            constraints.maxHeight == double.infinity;
 
         final BoxConstraints newConstraints;
         if (unboundedWidth || unboundedHeight) {
           newConstraints = BoxConstraints(
             minWidth: constraints.minWidth,
-            maxWidth: unboundedWidth ? fallbackSize.width : constraints.maxWidth,
+            maxWidth:
+                unboundedWidth ? fallbackSize.width : constraints.maxWidth,
             minHeight: constraints.minHeight,
-            maxHeight: unboundedHeight ? fallbackSize.height : constraints.maxHeight,
+            maxHeight:
+                unboundedHeight ? fallbackSize.height : constraints.maxHeight,
           );
         } else {
           newConstraints = constraints;
@@ -709,10 +735,12 @@ class _RenderFixedSizeTransitionStack extends RenderBox
     assert(_resolvedAlignment != null);
     RenderBox? child = firstChild;
     while (child != null) {
-      final StackParentData childParentData = child.parentData! as StackParentData;
+      final StackParentData childParentData =
+          child.parentData! as StackParentData;
 
       if (!childParentData.isPositioned) {
-        childParentData.offset = _resolvedAlignment!.alongOffset(size - child.size as Offset);
+        childParentData.offset =
+            _resolvedAlignment!.alongOffset(size - child.size as Offset);
       } else {
         layoutPositionedChild(
           child,
@@ -752,7 +780,8 @@ class _RenderFixedSizeTransitionStack extends RenderBox
         height: size.height - childParentData.bottom! - childParentData.top!,
       );
     } else if (childParentData.height != null) {
-      childConstraints = childConstraints.tighten(height: childParentData.height);
+      childConstraints =
+          childConstraints.tighten(height: childParentData.height);
     }
 
     child.layout(childConstraints, parentUsesSize: true);

--- a/lib/components/overlays/quick_settings/widgets/qs_shortcut_button.dart
+++ b/lib/components/overlays/quick_settings/widgets/qs_shortcut_button.dart
@@ -46,7 +46,10 @@ class QsShortcutButton extends StatelessWidget {
                   icon ?? Icons.add,
                   size: 16,
                 ),
-                if (title != null) const SizedBox(width: 8) else const SizedBox.shrink(),
+                if (title != null)
+                  const SizedBox(width: 8)
+                else
+                  const SizedBox.shrink(),
                 if (title != null)
                   Text(
                     title!,

--- a/lib/components/overlays/quick_settings/widgets/qs_titlebar.dart
+++ b/lib/components/overlays/quick_settings/widgets/qs_titlebar.dart
@@ -33,7 +33,10 @@ class QsTitlebar extends StatelessWidget implements PreferredSizeWidget {
       size: preferredSize,
       child: Row(
         children: [
-          if (leading == null && controller.canPop()) const BackButton() else if (leading != null) leading!,
+          if (leading == null && controller.canPop())
+            const BackButton()
+          else if (leading != null)
+            leading!,
           if (title != null)
             QuickActionButton(
               title: title,

--- a/lib/components/overlays/quick_settings/widgets/qs_tray_item.dart
+++ b/lib/components/overlays/quick_settings/widgets/qs_tray_item.dart
@@ -54,7 +54,8 @@ class _TrayMenuItemState extends State<QsTrayMenuItem> {
 
   @override
   Widget build(BuildContext context) {
-    final hasTooltipTitle = widget.item.tooltip?.title != null && widget.item.tooltip!.title.isNotEmpty;
+    final hasTooltipTitle = widget.item.tooltip?.title != null &&
+        widget.item.tooltip!.title.isNotEmpty;
     final hasTitle = widget.item.title != null && widget.item.title!.isNotEmpty;
     final String? title;
 
@@ -66,11 +67,17 @@ class _TrayMenuItemState extends State<QsTrayMenuItem> {
       title = null;
     }
 
-    final hasMenu = widget.item.menu != null && widget.item.menu!.children.isNotEmpty;
+    final hasMenu =
+        widget.item.menu != null && widget.item.menu!.children.isNotEmpty;
     final menu = widget.item.menu;
 
     final child = ContextMenu(
-      entries: hasMenu ? menu!.children.where((e) => e.visible).map((e) => DBusMenuEntry(e)).toList() : null,
+      entries: hasMenu
+          ? menu!.children
+              .where((e) => e.visible)
+              .map((e) => DBusMenuEntry(e))
+              .toList()
+          : null,
       onOpen: () {
         menu!.object.callEvent(
           menu.id,
@@ -124,7 +131,8 @@ class _TrayMenuItemState extends State<QsTrayMenuItem> {
                     height: 16,
                     width: 16,
                     themePath: widget.item.iconThemePath,
-                    image: widget.item.icon ?? const IconDataDBusImage(Icons.info),
+                    image:
+                        widget.item.icon ?? const IconDataDBusImage(Icons.info),
                   ),
                 ),
                 if (title != null) const SizedBox(width: 8),

--- a/lib/components/window/window_toolbar.dart
+++ b/lib/components/window/window_toolbar.dart
@@ -48,7 +48,8 @@ class _PangolinWindowToolbarState extends State<PangolinWindowToolbar> {
     final hierarchy = WindowHierarchy.of(context);
     final properties = WindowPropertyRegistry.of(context);
     final layout = LayoutState.of(context);
-    final fgColor = !Theme.of(context).darkMode ? Colors.grey[900]! : Colors.white;
+    final fgColor =
+        !Theme.of(context).darkMode ? Colors.grey[900]! : Colors.white;
 
     return GestureDetector(
       child: ContextMenu(
@@ -78,7 +79,10 @@ class _PangolinWindowToolbarState extends State<PangolinWindowToolbar> {
                   content: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      if (properties.info.icon != null) Image(image: properties.info.icon!) else const Icon(Icons.apps),
+                      if (properties.info.icon != null)
+                        Image(image: properties.info.icon!)
+                      else
+                        const Icon(Icons.apps),
                       const SizedBox(
                         height: 16,
                       ),
@@ -197,7 +201,8 @@ class _PangolinWindowToolbarState extends State<PangolinWindowToolbar> {
                           }
                         },
                         onDoubleTap: () => onDoubleTap(layout),
-                        onPanUpdate: (details) => onDrag(details, properties, layout),
+                        onPanUpdate: (details) =>
+                            onDrag(details, properties, layout),
                         onPanEnd: (details) => onDragEnd(
                           details,
                           hierarchy,
@@ -241,7 +246,8 @@ class _PangolinWindowToolbarState extends State<PangolinWindowToolbar> {
       _cursor = SystemMouseCursors.move;
     });
     _lastDetails = details;
-    final WindowDock dock = _getDockForPosition(hierarchy.wmBounds, details.globalPosition);
+    final WindowDock dock =
+        _getDockForPosition(hierarchy.wmBounds, details.globalPosition);
     if (_draggingDock != dock) {
       _draggingDock = dock;
       final layer = EffectsLayer.of(context);
@@ -325,7 +331,8 @@ class _PangolinWindowToolbarState extends State<PangolinWindowToolbar> {
     setState(() {
       _cursor = SystemMouseCursors.click;
     });
-    final WindowDock dock = _getDockForPosition(hierarchy.wmBounds, _lastDetails.globalPosition);
+    final WindowDock dock =
+        _getDockForPosition(hierarchy.wmBounds, _lastDetails.globalPosition);
     layout.dock = dock;
     final layer = EffectsLayer.of(context);
     layer?.endDockEffect();

--- a/lib/widgets/context_menu.dart
+++ b/lib/widgets/context_menu.dart
@@ -26,7 +26,8 @@ class ContextMenu extends StatefulWidget {
 }
 
 class _ContextMenuState extends State<ContextMenu> {
-  late final String controllerId = _MenuControllerRegistry.instance.register(MenuController());
+  late final String controllerId =
+      _MenuControllerRegistry.instance.register(MenuController());
   late Offset lastPosition;
 
   @override
@@ -40,10 +41,11 @@ class _ContextMenuState extends State<ContextMenu> {
     if (widget.entries == null || widget.entries!.isEmpty) return widget.child;
 
     return GestureDetector(
-      onSecondaryTapUp: (details) =>
-          _MenuControllerRegistry.instance.open(controllerId, position: details.localPosition),
+      onSecondaryTapUp: (details) => _MenuControllerRegistry.instance
+          .open(controllerId, position: details.localPosition),
       onLongPressDown: (details) => lastPosition = details.localPosition,
-      onLongPress: () => _MenuControllerRegistry.instance.open(controllerId, position: lastPosition),
+      onLongPress: () => _MenuControllerRegistry.instance
+          .open(controllerId, position: lastPosition),
       child: MenuAnchor(
         onOpen: widget.onOpen,
         onClose: widget.onClose,
@@ -57,7 +59,8 @@ class _ContextMenuState extends State<ContextMenu> {
         ),
         controller: _MenuControllerRegistry.instance.get(controllerId),
         anchorTapClosesMenu: true,
-        menuChildren: widget.entries!.map((e) => e.buildWrapper(context)).toList(),
+        menuChildren:
+            widget.entries!.map((e) => e.buildWrapper(context)).toList(),
         child: widget.child,
       ),
     );
@@ -98,7 +101,8 @@ abstract class BaseContextMenuItem {
     this.trailing,
   });
 
-  Widget buildWrapper(BuildContext context) => _EnabledBuilder(enabled: enabled, child: build(context));
+  Widget buildWrapper(BuildContext context) =>
+      _EnabledBuilder(enabled: enabled, child: build(context));
 
   Widget build(BuildContext context);
   Widget? buildLeading(BuildContext context) => leading;
@@ -126,8 +130,11 @@ class SubmenuMenuItem extends BaseContextMenuItem {
       menuChildren: menuChildren.map((e) => e.buildWrapper(context)).toList(),
       leadingIcon: buildLeading(context),
       trailingIcon: buildTrailing(context),
-      style: const ButtonStyle(
-        padding: MaterialStatePropertyAll(
+      style: ButtonStyle(
+        backgroundColor: MaterialStatePropertyAll<Color>(
+          Theme.of(context).colorScheme.background,
+        ),
+        padding: const MaterialStatePropertyAll(
           EdgeInsets.symmetric(horizontal: 16),
         ),
       ),
@@ -163,8 +170,11 @@ class ContextMenuItem extends BaseContextMenuItem {
       trailingIcon: buildTrailing(context),
       onPressed: onTap,
       shortcut: shortcut,
-      style: const ButtonStyle(
-        padding: MaterialStatePropertyAll(
+      style: ButtonStyle(
+        backgroundColor: MaterialStatePropertyAll<Color>(
+          Theme.of(context).colorScheme.background,
+        ),
+        padding: const MaterialStatePropertyAll(
           EdgeInsets.symmetric(horizontal: 16),
         ),
       ),

--- a/lib/widgets/context_menu.dart
+++ b/lib/widgets/context_menu.dart
@@ -134,7 +134,6 @@ class SubmenuMenuItem extends BaseContextMenuItem {
       leadingIcon: buildLeading(context),
       trailingIcon: buildTrailing(context),
       style: ButtonStyle(
-        shape: const MaterialStatePropertyAll(Constants.smallShape),
         backgroundColor: MaterialStatePropertyAll<Color>(
           Theme.of(context).colorScheme.background,
         ),
@@ -175,7 +174,6 @@ class ContextMenuItem extends BaseContextMenuItem {
       onPressed: onTap,
       shortcut: shortcut,
       style: ButtonStyle(
-        shape: const MaterialStatePropertyAll(Constants.smallShape),
         backgroundColor: MaterialStatePropertyAll<Color>(
           Theme.of(context).colorScheme.background,
         ),

--- a/lib/widgets/context_menu.dart
+++ b/lib/widgets/context_menu.dart
@@ -132,20 +132,23 @@ class SubmenuMenuItem extends BaseContextMenuItem {
 
   @override
   Widget build(BuildContext context) {
-    return SubmenuButton(
-      menuChildren: menuChildren.map((e) => e.buildWrapper(context)).toList(),
-      leadingIcon: buildLeading(context),
-      trailingIcon: buildTrailing(context),
-      style: ButtonStyle(
-        shape: const MaterialStatePropertyAll(Constants.smallShape),
-        backgroundColor: MaterialStatePropertyAll<Color>(
-          Theme.of(context).colorScheme.background,
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 2.0),
+      child: SubmenuButton(
+        menuChildren: menuChildren.map((e) => e.buildWrapper(context)).toList(),
+        leadingIcon: buildLeading(context),
+        trailingIcon: buildTrailing(context),
+        style: ButtonStyle(
+          shape: const MaterialStatePropertyAll(Constants.smallShape),
+          backgroundColor: MaterialStatePropertyAll<Color>(
+            Theme.of(context).colorScheme.background,
+          ),
+          padding: const MaterialStatePropertyAll(
+            EdgeInsets.symmetric(horizontal: 16),
+          ),
         ),
-        padding: const MaterialStatePropertyAll(
-          EdgeInsets.symmetric(horizontal: 16),
-        ),
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/lib/widgets/context_menu.dart
+++ b/lib/widgets/context_menu.dart
@@ -50,6 +50,12 @@ class _ContextMenuState extends State<ContextMenu> {
         onOpen: widget.onOpen,
         onClose: widget.onClose,
         style: MenuStyle(
+          backgroundColor: MaterialStatePropertyAll<Color>(
+            Theme.of(context).colorScheme.background,
+          ),
+          padding: const MaterialStatePropertyAll(
+            EdgeInsets.only(left: 6, right: 6, top: 14, bottom: 12),
+          ),
           shape: const MaterialStatePropertyAll(Constants.mediumShape),
           side: MaterialStatePropertyAll(
             BorderSide(
@@ -131,6 +137,7 @@ class SubmenuMenuItem extends BaseContextMenuItem {
       leadingIcon: buildLeading(context),
       trailingIcon: buildTrailing(context),
       style: ButtonStyle(
+        shape: const MaterialStatePropertyAll(Constants.smallShape),
         backgroundColor: MaterialStatePropertyAll<Color>(
           Theme.of(context).colorScheme.background,
         ),
@@ -160,25 +167,29 @@ class ContextMenuItem extends BaseContextMenuItem {
   Widget build(BuildContext context) {
     final Widget? leading = buildLeading(context);
 
-    return MenuItemButton(
-      leadingIcon: leading != null
-          ? IconTheme.merge(
-              data: Theme.of(context).iconTheme.copyWith(size: 20),
-              child: leading,
-            )
-          : null,
-      trailingIcon: buildTrailing(context),
-      onPressed: onTap,
-      shortcut: shortcut,
-      style: ButtonStyle(
-        backgroundColor: MaterialStatePropertyAll<Color>(
-          Theme.of(context).colorScheme.background,
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 2),
+      child: MenuItemButton(
+        leadingIcon: leading != null
+            ? IconTheme.merge(
+                data: Theme.of(context).iconTheme.copyWith(size: 20),
+                child: leading,
+              )
+            : null,
+        trailingIcon: buildTrailing(context),
+        onPressed: onTap,
+        shortcut: shortcut,
+        style: ButtonStyle(
+          shape: const MaterialStatePropertyAll(Constants.smallShape),
+          backgroundColor: MaterialStatePropertyAll<Color>(
+            Theme.of(context).colorScheme.background,
+          ),
+          padding: const MaterialStatePropertyAll(
+            EdgeInsets.symmetric(horizontal: 16),
+          ),
         ),
-        padding: const MaterialStatePropertyAll(
-          EdgeInsets.symmetric(horizontal: 16),
-        ),
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/lib/widgets/context_menu.dart
+++ b/lib/widgets/context_menu.dart
@@ -53,15 +53,6 @@ class _ContextMenuState extends State<ContextMenu> {
           backgroundColor: MaterialStatePropertyAll<Color>(
             Theme.of(context).colorScheme.background,
           ),
-          padding: MaterialStatePropertyAll(
-            EdgeInsets.only(
-              left: 4 - VisualDensity.compact.horizontal,
-              right: 4 - VisualDensity.compact.horizontal,
-              top: 4 - VisualDensity.compact.vertical,
-              bottom: 2 - VisualDensity.compact.vertical,
-            ),
-          ),
-          visualDensity: VisualDensity.standard,
           shape: const MaterialStatePropertyAll(Constants.mediumShape),
           side: MaterialStatePropertyAll(
             BorderSide(
@@ -138,24 +129,20 @@ class SubmenuMenuItem extends BaseContextMenuItem {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 2.0),
-      child: SubmenuButton(
-        menuChildren: menuChildren.map((e) => e.buildWrapper(context)).toList(),
-        leadingIcon: buildLeading(context),
-        trailingIcon: buildTrailing(context),
-        style: ButtonStyle(
-          shape: const MaterialStatePropertyAll(Constants.smallShape),
-          backgroundColor: MaterialStatePropertyAll<Color>(
-            Theme.of(context).colorScheme.background,
-          ),
-          visualDensity: VisualDensity.compact,
-          padding: const MaterialStatePropertyAll(
-            EdgeInsets.symmetric(horizontal: 16),
-          ),
+    return SubmenuButton(
+      menuChildren: menuChildren.map((e) => e.buildWrapper(context)).toList(),
+      leadingIcon: buildLeading(context),
+      trailingIcon: buildTrailing(context),
+      style: ButtonStyle(
+        shape: const MaterialStatePropertyAll(Constants.smallShape),
+        backgroundColor: MaterialStatePropertyAll<Color>(
+          Theme.of(context).colorScheme.background,
         ),
-        child: child,
+        padding: const MaterialStatePropertyAll(
+          EdgeInsets.symmetric(horizontal: 16),
+        ),
       ),
+      child: child,
     );
   }
 }
@@ -177,30 +164,26 @@ class ContextMenuItem extends BaseContextMenuItem {
   Widget build(BuildContext context) {
     final Widget? leading = buildLeading(context);
 
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 2),
-      child: MenuItemButton(
-        leadingIcon: leading != null
-            ? IconTheme.merge(
-                data: Theme.of(context).iconTheme.copyWith(size: 20),
-                child: leading,
-              )
-            : null,
-        trailingIcon: buildTrailing(context),
-        onPressed: onTap,
-        shortcut: shortcut,
-        style: ButtonStyle(
-          shape: const MaterialStatePropertyAll(Constants.smallShape),
-          backgroundColor: MaterialStatePropertyAll<Color>(
-            Theme.of(context).colorScheme.background,
-          ),
-          visualDensity: VisualDensity.compact,
-          padding: const MaterialStatePropertyAll(
-            EdgeInsets.symmetric(horizontal: 16),
-          ),
+    return MenuItemButton(
+      leadingIcon: leading != null
+          ? IconTheme.merge(
+              data: Theme.of(context).iconTheme.copyWith(size: 20),
+              child: leading,
+            )
+          : null,
+      trailingIcon: buildTrailing(context),
+      onPressed: onTap,
+      shortcut: shortcut,
+      style: ButtonStyle(
+        shape: const MaterialStatePropertyAll(Constants.smallShape),
+        backgroundColor: MaterialStatePropertyAll<Color>(
+          Theme.of(context).colorScheme.background,
         ),
-        child: child,
+        padding: const MaterialStatePropertyAll(
+          EdgeInsets.symmetric(horizontal: 16),
+        ),
       ),
+      child: child,
     );
   }
 }

--- a/lib/widgets/context_menu.dart
+++ b/lib/widgets/context_menu.dart
@@ -53,9 +53,15 @@ class _ContextMenuState extends State<ContextMenu> {
           backgroundColor: MaterialStatePropertyAll<Color>(
             Theme.of(context).colorScheme.background,
           ),
-          padding: const MaterialStatePropertyAll(
-            EdgeInsets.only(left: 6, right: 6, top: 14, bottom: 12),
+          padding: MaterialStatePropertyAll(
+            EdgeInsets.only(
+              left: 4 - VisualDensity.compact.horizontal,
+              right: 4 - VisualDensity.compact.horizontal,
+              top: 4 - VisualDensity.compact.vertical,
+              bottom: 2 - VisualDensity.compact.vertical,
+            ),
           ),
+          visualDensity: VisualDensity.standard,
           shape: const MaterialStatePropertyAll(Constants.mediumShape),
           side: MaterialStatePropertyAll(
             BorderSide(
@@ -143,6 +149,7 @@ class SubmenuMenuItem extends BaseContextMenuItem {
           backgroundColor: MaterialStatePropertyAll<Color>(
             Theme.of(context).colorScheme.background,
           ),
+          visualDensity: VisualDensity.compact,
           padding: const MaterialStatePropertyAll(
             EdgeInsets.symmetric(horizontal: 16),
           ),
@@ -187,6 +194,7 @@ class ContextMenuItem extends BaseContextMenuItem {
           backgroundColor: MaterialStatePropertyAll<Color>(
             Theme.of(context).colorScheme.background,
           ),
+          visualDensity: VisualDensity.compact,
           padding: const MaterialStatePropertyAll(
             EdgeInsets.symmetric(horizontal: 16),
           ),

--- a/lib/widgets/quick_button.dart
+++ b/lib/widgets/quick_button.dart
@@ -80,8 +80,14 @@ class _QuickActionButtonState extends State<QuickActionButton> {
                           mainAxisSize: MainAxisSize.min,
                           children: [
                             widget.leading ?? const SizedBox.shrink(),
-                            if (!(titleIsNull || leadingIsNull)) const SizedBox(width: 8) else const SizedBox.shrink(),
-                            if (!titleIsNull) Text(widget.title!) else const SizedBox.shrink(),
+                            if (!(titleIsNull || leadingIsNull))
+                              const SizedBox(width: 8)
+                            else
+                              const SizedBox.shrink(),
+                            if (!titleIsNull)
+                              Text(widget.title!)
+                            else
+                              const SizedBox.shrink(),
                           ],
                         )
                       : widget.leading ?? const SizedBox.shrink(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
     git: 
       url: https://github.com/dahliaOS/zenit_ui.git
       # change before merge
-      ref: Version-0.0.11
+      ref: v0.0.11
 
 
 dev_dependencies: 


### PR DESCRIPTION
Matches the context menu backgroundColor with the desktop. Also a bunch of formatting fixes and fixing the zenut_ui dependency that wouldn't compile.

Before:

![Screenshot from 2023-07-21 21-43-42](https://github.com/dahliaOS/pangolin_desktop/assets/73116038/2f56ed3a-fba3-46f8-bc92-8de27eb26751)

![Screenshot from 2023-07-21 21-43-29](https://github.com/dahliaOS/pangolin_desktop/assets/73116038/b9dd607f-9bf7-4dad-93dc-fe85b80fe5cb)

After:

![Screenshot from 2023-07-21 21-42-41](https://github.com/dahliaOS/pangolin_desktop/assets/73116038/84093aa7-3925-4b1c-ab7c-92b685adb16c)

![Screenshot from 2023-07-21 21-42-24](https://github.com/dahliaOS/pangolin_desktop/assets/73116038/5ce76dd1-968a-45bb-9eae-873dc9ec1efc)

