### PR TITLE
Change cached_network_image source

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,11 @@ environment:
 
 dependencies: 
   animations: ^2.0.7
-  cached_network_image: ^3.2.0
+  #TODO change once the pub version is fixed
+  cached_network_image:
+    git:
+      url: https://github.com/gauravmehta13/flutter_cached_network_image.git
+      path: cached_network_image
   collection: ^1.17.1
   dahlia_shared:
     git: 


### PR DESCRIPTION
The default pub.dev source is broken and fails the build process.
