### PR TITLE
Fix: Add null check for notification object in ReplaceNotificationEvent

### DIFF
--- a/lib/components/overlays/notifications/widgets/listener.dart
+++ b/lib/components/overlays/notifications/widgets/listener.dart
@@ -35,6 +35,10 @@ mixin NotificationServiceListener<T extends StatefulWidget> on State<T> {
 
         setState(() {});
       case ReplaceNotificationEvent(id: final id, oldId: final oldId):
+        final UserNotification? notification = service.getNotification(id);
+
+        if (notification == null) return;
+
         onNotificationReplaced(oldId, id);
       default:
         break;


### PR DESCRIPTION
## Summary

This PR adds a null check for the notification object in the `ReplaceNotificationEvent` case of the `_notificationEventListener` method.

## Problem

The `ReplaceNotificationEvent` case was calling `onNotificationReplaced(oldId, id)` without verifying that the new notification exists. If the notification service returns null for a non-existent notification ID, this could lead to unexpected behavior or crashes downstream.

## Solution

Added the same null-check pattern used in `ShowNotificationEvent`:
- Retrieve the notification using `service.getNotification(id)`
- Return early if the notification is null
- Only call `onNotificationReplaced` if the notification exists

## Testing

This change ensures consistency with the existing null-check pattern in `ShowNotificationEvent` and prevents potential null pointer issues when notification IDs are invalid or stale.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.